### PR TITLE
Prevent from using gson to  deserialized to map

### DIFF
--- a/json2flat/src/main/java/com/github/opendevl/OrderJson.java
+++ b/json2flat/src/main/java/com/github/opendevl/OrderJson.java
@@ -1,78 +1,67 @@
 package com.github.opendevl;
 
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+
 import java.lang.reflect.Type;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.reflect.TypeToken;
 
 public class OrderJson {
 	
 	Type type = new TypeToken<Map<String, Object>>(){}.getType();
 	
-	Map<String, Object> origMap = null;
-	
-	Map<String, Object> jsonPre = null;
-	Map<String, Object> jsonArr = null;
-	Map<String, Object> jsonObj = null;
-	
+	Map<String, JsonElement> jsonPre = null;
+	Map<String, JsonElement> jsonArr = null;
+	Map<String, JsonElement> jsonObj = null;
+
 	Gson jsonToFro = null;
 	
 	public OrderJson(){
-		
-		jsonToFro = new Gson();
+		jsonToFro =  new Gson();
 	}
 	
 	public JsonElement orderJson(JsonElement ele){
 		
-		origMap  = new LinkedHashMap<String, Object>();
-		
-		jsonPre = new LinkedHashMap<String, Object>();
-		jsonArr = new LinkedHashMap<String, Object>();
-		jsonObj = new LinkedHashMap<String, Object>();
-		
-		//converting JsonElement to Map
-		origMap = jsonToFro.fromJson(ele, type);
-		
-		//Iterating the Map object to to get type of Object
-		for(Map.Entry<String, Object> entry : origMap.entrySet()){
-			
+		jsonPre = new LinkedHashMap<String, JsonElement>();
+		jsonArr = new LinkedHashMap<String, JsonElement>();
+		jsonObj = new LinkedHashMap<String, JsonElement>();
+
+		JsonObject jsonObject = ele.getAsJsonObject();
+		for(Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
 			try{
 				//adding check if value of key in json is null
-				if(entry.getValue() == null || 
-						entry.getValue().getClass().getSimpleName().equals("ArrayList")){
-					
+				if(entry.getValue() == null ||
+						entry.getValue().getClass().equals(JsonArray.class)){
+
 					//if Object is of type ArrayList push it to jsonArr Map
 					jsonArr.put(entry.getKey(), entry.getValue());
-					
+
 				}else{
-					
+
 					//if Object is of type Premitive push it to jsonPre.
 					jsonPre.put(entry.getKey(), entry.getValue());
 				}
 			}catch(Exception ex){
 				ex.printStackTrace();
 			}
-			//Yet to descide about if type is of JsonObject
-			
+			//Yet to decide about if type is of JsonObject
 		}
+
 		
 		/* Keeping Order - 
 		 * 		1) JSON premitive
 		 * 		2) JSON Array
-		 * 		3) JSON Object ( order of JSON Object is yet to be descided)
+		 * 		3) JSON Object ( order of JSON Object is yet to be decided)
 		 * */
 		
-		//appending jsonArr map to jsonPre map in order to mantain order.
+		//appending jsonArr map to jsonPre map in order to maintain order.
 		jsonPre.putAll(jsonArr);
 		
 		//reconstructing the JSON from Map Objects and returning
 		
 		return jsonToFro.toJsonTree(jsonPre, LinkedHashMap.class);
-		
+
 	}
-	
 	
 }


### PR DESCRIPTION
Use gson.fromJson will have some side effect, such as it will convert double number to scientific annotation expression, which sometimes will cause problem.
The logic here don't have to parse to map, it's better to modify it.